### PR TITLE
Tracers emit light

### DIFF
--- a/GLDEFS
+++ b/GLDEFS
@@ -79,6 +79,15 @@ pulselight WeaponUpgradeSpawner
     interval 0.8
 }
 
+//Tracer light (TRAC)
+pulselight TracerLight
+{
+    color 1.0 1.0 0.9
+    size 24
+    secondarySize 32
+    interval 0.2
+}
+
 pointlight DemonTechImpact
 {
     color 6.0 0.3 0.0

--- a/actors/Effects/TRACERS.dec
+++ b/actors/Effects/TRACERS.dec
@@ -18,7 +18,7 @@ Actor Tracer: FastProjectile
 	states
 	{
 	Spawn:
-		TRAC A 1 BRIGHT
+		TRAC A 1 BRIGHT Light("TracerLight")
 		Loop
 	Death:
 		TNT1 A 0


### PR DESCRIPTION
I was playing a level with dark areas and noticed the tracers themselves do not emit light, and the bright function felt like it was not enough.

This just adds a light to the tracers spawn state.  The color of the light matches the center of the tracer.

I did not notice a performance hit while using this.  However if you do (say a group of persons who have older/slower hardware) it is simple enough to turn this off or even perhaps hide this behind a cvar.