### PR TITLE
Tracer light is now activated by server CVAR

### DIFF
--- a/CVARINFO
+++ b/CVARINFO
@@ -4,6 +4,7 @@ user bool py_weaponwheel_musicfade = false;
 user bool pb_toggle_aim_hold = false;
 
 user int bd_bloodamount	= 2;
+user int PB_tracerlight	= 0;
 user int bd_lowgraphicsmode = 0;
 server int bd_classicmonsters = 0;
 server int bd_TraditionalMode = 0;

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -389,6 +389,10 @@ OptionMenu "RenderingSettings"
 	StaticText "Disables the screen scratches, bullet holes, and cracks"
 	StaticText " "
 	
+	Option "Enable Light From Tracers",				"PB_tracerlight", "OnOff"
+	StaticText "Enables GL light emitted from tracers"
+	StaticText " "
+
 	Option "Disable Fade out effects when exiting a map", "pb_fadeonmapexit", "YesOrNoFalse"
 	StaticText "Disables the fade out effects when completing a map"
 	StaticText " "

--- a/actors/Effects/TRACERS.dec
+++ b/actors/Effects/TRACERS.dec
@@ -18,6 +18,11 @@ Actor Tracer: FastProjectile
 	states
 	{
 	Spawn:
+		TNT1 A 0 A_JumpIf(GetCvar("PB_TracerLight") >=1,"Spawn2")
+	Spawn1:
+		TRAC A 1 BRIGHT 
+		Loop
+	Spawn2:
 		TRAC A 1 BRIGHT Light("TracerLight")
 		Loop
 	Death:


### PR DESCRIPTION
This is just in case someone would be afraid of the performance hit from the tracer light added earlier.  It now is activated by a server CVAR in the visuals menu.

Now there still is a GL light that comes on upon death/puff which has nothing to do with my light, which is looped during travel of the tracer itself.