### PR TITLE
Rail gun laser pointer

### DIFF
--- a/actors/Weapons/Slot7/RAILGUN.dec
+++ b/actors/Weapons/Slot7/RAILGUN.dec
@@ -543,7 +543,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_1:
 			R036 BCDEF 1 BRIGHT {
-				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
+				A_RailAttack(0, 0, 0,none, none, RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "Laser_Red_CyberDemon", 0, 0, 4000, 0, 1, 1.0, "Tracer_Trail_Red_Cyberdemon", -7,0,0);
 				A_SetBlend("Red",0.1,6);
 				if(CountInv("RailgunAmmo") < 1) {
 					return state("Laser_Blast");
@@ -557,7 +557,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R036 G 1 BRIGHT {
-				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
+				A_RailAttack(0, 0, 0,none, none, RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "Laser_Red_CyberDemon", 0, 0, 4000, 0, 1, 1.0, "Tracer_Trail_Red_Cyberdemon", -7,0,0);
 				A_SetBlend("Red",0.1,6);
 				if(JustReleased(BT_ATTACK) || !PressingFire()) {
 					return state("Laser_Blast");
@@ -571,7 +571,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_2:
 			R036 HIJKL 1 BRIGHT {
-				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
+				A_RailAttack(0, 0, 0,none, none, RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "Laser_Red_CyberDemon", 0, 0, 4000, 0, 1, 1.0, "Tracer_Trail_Red_Cyberdemon", -7,0,0);
 				A_SetBlend("Red",0.18,6);
 				if(CountInv("RailgunAmmo") < 1) {
 					return state("Laser_Blast");
@@ -584,7 +584,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R036 M 1 BRIGHT {
-				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
+				A_RailAttack(0, 0, 0,none, none, RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "Laser_Red_CyberDemon", 0, 0, 4000, 0, 1, 1.0, "Tracer_Trail_Red_Cyberdemon", -7,0,0);
 				A_SetBlend("Red",0.18,6);
 				if(JustReleased(BT_ATTACK) || !PressingFire()) {
 					return state("Laser_Blast");
@@ -599,7 +599,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_3:
 			R036 NOPQR 1 BRIGHT {
-				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
+				A_RailAttack(0, 0, 0,none, none, RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "Laser_Red_CyberDemon", 0, 0, 4000, 0, 1, 1.0, "Tracer_Trail_Red_Cyberdemon", -7,0,0);
 				A_SetBlend("Red",0.26,6);
 				if(CountInv("RailgunAmmo") < 1) {
 					return state("Laser_Blast");
@@ -612,7 +612,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R036 S 1 BRIGHT {
-				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
+				A_RailAttack(0, 0, 0,none, none, RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "Laser_Red_CyberDemon", 0, 0, 4000, 0, 1, 1.0, "Tracer_Trail_Red_Cyberdemon", -7,0,0);
 				A_SetBlend("Red",0.26,6);
 				if(JustReleased(BT_ATTACK) || !PressingFire()) {
 					return state("Laser_Blast");
@@ -626,7 +626,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_4:
 			R036 TUVWX 1 BRIGHT {
-				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
+				A_RailAttack(0, 0, 0,none, none, RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "Laser_Red_CyberDemon", 0, 0, 4000, 0, 1, 1.0, "Tracer_Trail_Red_Cyberdemon", -7,0,0);
 				A_SetBlend("Red",0.32,6);
 				if(CountInv("RailgunLaserCharge") == 60) {
 					A_StartSound("weapons/railgun/lasercharge4", CHAN_AUTO, CHANF_OVERLAP);
@@ -642,7 +642,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R036 Y 1 BRIGHT {
-				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
+				A_RailAttack(0, 0, 0,none, none, RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "Laser_Red_CyberDemon", 0, 0, 4000, 0, 1, 1.0, "Tracer_Trail_Red_Cyberdemon", -7,0,0);
 				A_SetBlend("Red",0.32,6);
 				if(CountInv("RailgunLaserCharge") == 60) {
 					A_StartSound("weapons/railgun/lasercharge4", CHAN_AUTO, CHANF_OVERLAP);


### PR DESCRIPTION
Makes the laser pointer for the railgun the same as the one used on the cyber demon

-Rendering distance is now upped to 4000 units.  Half of maximum.
-All rail attacks (this one here, as well as the previous one it replaces) do not bob/sway with the weapon and will look funny if there is a lot of bobbing and running, my laser pointer excaserbates that by being solid.